### PR TITLE
add full package path to import

### DIFF
--- a/botvac_tools/lds_tools/tests/test_lds_tools.py
+++ b/botvac_tools/lds_tools/tests/test_lds_tools.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from botvac_tools.lds_tools import Scan
+from botvac_tools.lds_tools.lds_tools import Scan
 
 
 class TestScanObject(TestCase):


### PR DESCRIPTION
this pull request fixes the import error in the test; because lds_tools is in both an lds_tools module (file) and package (directory) the import path has another lds_tools after it
